### PR TITLE
adding cors origin support to graphql and nestjs

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,7 +23,7 @@ import { ImageModule } from './image/image.module';
         outputAs: 'class',
       },
       cors: {
-        origin: '*',
+        origin: true,
         credentials: true,
       },
     }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,11 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: true,
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
   const host = '0.0.0.0';
   await app.listen(process.env.PORT || 3001, host);
 }


### PR DESCRIPTION
Closes #7 

Successfully added cors origin headers to NestJS and GraphQL files. Tested making queries/mutations on the frontend and no longer getting blocked by CORS ORIGIN issues,